### PR TITLE
Make sure that we can store the generated cert

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,6 +60,7 @@ fi
 export PATH=/usr/safenet/lunaclient/bin:$PATH
 
 if [ ! -f "${SAFENET}/cert/client/${HOSTNAME}.pem" -o ! -f "${SAFENET}/cert/client/${HOSTNAME}Key.pem" ]; then
+   mkdir -p "${SAFENET}/cert/client"
    vtl createCert -n ${HOSTNAME}
 fi
 


### PR DESCRIPTION
Prevent errors like:
Writing new private key to /usr/safenet/lunaclient/cert/client/<fqdn>Key.pem

Error:  Could not create client certificate or private key. Ensure
        the current user has read and write permissions to the
        directory indicated by the 'ClientCertFile' and
        'ClientPrivKeyFile' lines in the Chrystoki.conf file.