### PR TITLE
Stable pyeleven and remove legacy luna

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-LUNA=6.2
+LUNA=7.4
 PYELEVENSRC=git+https://github.com/IdentityPython/pyeleven.git\#egg=pyeleven
 PYELEVEN=0.0.1
 NAME=luna-client
@@ -7,8 +7,6 @@ VERSION=$(LUNA)-$(PYELEVEN)
 all: build push
 
 dist:
-	$(MAKE) LUNA=6.2 PYELEVENSRC=git+https://github.com/IdentityPython/pyeleven.git\#egg=pyeleven PYELEVEN="$(PYELEVEN)"
-	$(MAKE) LUNA=7.2 PYELEVENSRC=git+https://github.com/IdentityPython/pyeleven.git\#egg=pyeleven PYELEVEN="$(PYELEVEN)"
 	$(MAKE) LUNA=7.4 PYELEVENSRC=git+https://github.com/IdentityPython/pyeleven.git\#egg=pyeleven PYELEVEN="$(PYELEVEN)"
 
 .PHONY: Dockerfile


### PR DESCRIPTION
* Remove older version of luna which we no longer use
* Don't overwrite old images with newer python (and as a bonus use a stable tag of pyeleven) - no succesful builds since 25th of March 2025.

To not mess up older images it's recommended to merge this before #2.